### PR TITLE
reviewed biicode.conf file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /bii/
+bin
+bii

--- a/biicode.conf
+++ b/biicode.conf
@@ -4,5 +4,5 @@ theambient/bitstream: 0
 
 [includes]
 
-bitstream/mpeg/*.h: theambient/bitstream/mpeg/
-bitstream/mpeg/psi/*.h: theambient/bitstream/mpeg/psi
+bitstream/mpeg/*.h: theambient/bitstream
+bitstream/mpeg/psi/*.h: theambient/bitstream


### PR DESCRIPTION
Hi @theambient,

Just updated your biitest project, it's now working - to try it:

```
git clone https://github.com/MariadeAnton/biitest.git
cd biitest
bii init -L
bii build
```
And that's it

Trick was the `[includes]` mapping, for example to use:
`#include "theambient/bitstream/bitstream/mpeg/aac.h"`

the includes section splits that name in two parts:

```
[includes]

bitstream/mpeg/aac.h: theambient/bitstream
```

or using a pattern like you were doing:

```
[includes]

bitstream/mpeg/*.h: theambient/bitstream
```

Hope this explains things :)

